### PR TITLE
Fix timeline-panel width

### DIFF
--- a/assets/css/resumecard.css
+++ b/assets/css/resumecard.css
@@ -168,6 +168,7 @@ hr {
 }
 
 .timeline > li > .timeline-panel {
+    width:100%;
     float: left;
     border: 1px solid #d4d4d4;
     border-radius: 2px;


### PR DESCRIPTION
When no description is provided, the timeline panel do not fill the full width available.
